### PR TITLE
Fixes "\n\r" being the record separator and dynamically add system supported record separator

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/map/csv/sinkmapper/CSVSinkMapper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/map/csv/sinkmapper/CSVSinkMapper.java
@@ -81,11 +81,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
                                 "define stream BarStream (symbol string, price float, volume long);",
                         description = "Above configuration will perform a default CSV output mapping, which will  " +
                                 "generate output as follows:\n " +
-                                "WSO2,55.6,100\r\n" +
+                                "WSO2,55.6,100<OS supported line separator>" +
 
                                 "If header is true and delimiter is \"-\", then the output will be as follows:\n" +
-                                "symbol-price-volume\r\n" +
-                                "WSO2-55.6-100\r\n"
+                                "symbol-price-volume<OS supported line separator>" +
+                                "WSO2-55.6-100<OS supported line separator>"
                 ),
                 @Example(
                         syntax = "@sink(type='inMemory', topic='{{symbol}}', @map(type='csv',header='true'," +
@@ -99,13 +99,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
                                 "If header is true and delimiter is \"-\", then the output will be as follows:\n" +
                                 "symbol-price-volume\r\n" +
-                                "WSO2-55.6-100\r\n" +
+                                "WSO2-55.6-100<OS supported line separator>" +
 
                                 "If event grouping is enabled, then the output is as follows:\n" +
 
-                                "WSO2-55.6-100System.lineSeparator()\n" +
-                                "WSO2-55.6-100System.lineSeparator()\n" +
-                                "WSO2-55.6-100System.lineSeparator()\n"
+                                "WSO2-55.6-100<OS supported line separator>\n" +
+                                "WSO2-55.6-100<OS supported line separator>\n" +
+                                "WSO2-55.6-100<OS supported line separator>\n"
                 )
         }
 )
@@ -223,6 +223,7 @@ public class CSVSinkMapper extends SinkMapper {
             if (isAddHeader) {
                 CSVFormat.DEFAULT
                         .withDelimiter(delimiter)
+                        .withRecordSeparator(System.lineSeparator())
                         .withNullString("null")
                         .withQuote('\"')
                         .printRecord(stringWriter, headerOfData);
@@ -254,6 +255,7 @@ public class CSVSinkMapper extends SinkMapper {
                         }
                         CSVFormat.DEFAULT
                                 .withDelimiter(delimiter)
+                                .withRecordSeparator(System.lineSeparator())
                                 .withNullString("null")
                                 .withQuote('\"')
                                 .printRecord(stringWriter, dataOfEvent);
@@ -279,6 +281,7 @@ public class CSVSinkMapper extends SinkMapper {
                         dataOfEvent = event.getData();
                         CSVFormat.DEFAULT
                                 .withDelimiter(delimiter)
+                                .withRecordSeparator(System.lineSeparator())
                                 .withNullString("null")
                                 .withQuote('\"')
                                 .printRecord(stringWriter, dataOfEvent);
@@ -317,6 +320,7 @@ public class CSVSinkMapper extends SinkMapper {
             if (isAddHeader) {
                 CSVFormat.DEFAULT
                         .withDelimiter(delimiter)
+                        .withRecordSeparator(System.lineSeparator())
                         .withNullString("null")
                         .withQuote('\"')
                         .printRecord(stringWriter, headerOfData);
@@ -326,6 +330,7 @@ public class CSVSinkMapper extends SinkMapper {
             }
             CSVFormat.DEFAULT
                     .withDelimiter(delimiter)
+                    .withRecordSeparator(System.lineSeparator())
                     .withNullString("null")
                     .withQuote('\"')
                     .printRecord(stringWriter, dataOfEvent);

--- a/component/src/test/java/org/wso2/extension/siddhi/map/csv/sinkmapper/TestCaseOfCSVSinkMapper.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/map/csv/sinkmapper/TestCaseOfCSVSinkMapper.java
@@ -119,13 +119,13 @@ public class TestCaseOfCSVSinkMapper {
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 2, wso2Count.get());
         //AssertJUnit.assertEquals("Incorrect number of events consumed!", 2, ibmCount.get());
         //assert default mapping
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,55.645,100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,55.645,100" + System.lineSeparator(),
                                  onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,75.0,100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,75.0,100" + System.lineSeparator(),
                                  onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,57.6,100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,57.6,100" + System.lineSeparator(),
                                  onMessageList.get(2).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,null,57\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,null,57" + System.lineSeparator(),
                                  onMessageList.get(3).toString());
         executionPlanRuntime.shutdown();
 
@@ -176,14 +176,14 @@ public class TestCaseOfCSVSinkMapper {
         //assert event count
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 4, companyCount.get());
 
-        AssertJUnit.assertEquals("Incorrect mapping!", "\"WSO2,NO10,Palam groove Rd\",55.645,100\r\n"
-                , onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "\"IBM,Colombo 7\",75.0,100\r\n",
-                                 onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "\"WSO2,Colombo 10\",57.6,100\r\n",
-                                 onMessageList.get(2).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "\"IBM,Colombo 3\",null,57\r\n",
-                                 onMessageList.get(3).toString());
+        AssertJUnit.assertEquals("Incorrect mapping!", "\"WSO2,NO10,Palam groove Rd\",55.645,100" +
+                        System.lineSeparator(), onMessageList.get(0).toString());
+        AssertJUnit.assertEquals("Incorrect mapping!", "\"IBM,Colombo 7\",75.0,100" +
+                        System.lineSeparator(), onMessageList.get(1).toString());
+        AssertJUnit.assertEquals("Incorrect mapping!", "\"WSO2,Colombo 10\",57.6,100" +
+                        System.lineSeparator(), onMessageList.get(2).toString());
+        AssertJUnit.assertEquals("Incorrect mapping!", "\"IBM,Colombo 3\",null,57" +
+                        System.lineSeparator(), onMessageList.get(3).toString());
         executionPlanRuntime.shutdown();
         InMemoryBroker.unsubscribe(subscriberCompany);
         siddhiManager.shutdown();
@@ -231,11 +231,11 @@ public class TestCaseOfCSVSinkMapper {
         //assert event count
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 3, companyCount.get());
         //assert default mapping
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2#@$,55.6,100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2#@$,55.6,100" + System.lineSeparator(),
                                  onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,75.6,100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,75.6,100" + System.lineSeparator(),
                                  onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "null,null,100\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "null,null,100" + System.lineSeparator()
                 , onMessageList.get(2).toString());
         executionPlanRuntime.shutdown();
 
@@ -301,11 +301,11 @@ public class TestCaseOfCSVSinkMapper {
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 2, wso2Count.get());
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 1, ibmCount.get());
         //assert default mapping
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,55.6,null\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,55.6,null" + System.lineSeparator()
                 , onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,null,100\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,null,100" + System.lineSeparator()
                 , onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,57.6,100\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,57.6,100" + System.lineSeparator()
                 , onMessageList.get(2).toString());
         executionPlanRuntime.shutdown();
 
@@ -375,15 +375,15 @@ public class TestCaseOfCSVSinkMapper {
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 3, wso2Count.get());
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 2, ibmCount.get());
         //assert default mapping
-        AssertJUnit.assertEquals("Incorrect mapping!", "symbol-price-volume\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "symbol-price-volume" + System.lineSeparator()
                 , onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-55.645-100\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-55.645-100" + System.lineSeparator()
                 , onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-75.0-100\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-75.0-100" + System.lineSeparator()
                 , onMessageList.get(2).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-57.6-100\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-57.6-100" + System.lineSeparator()
                 , onMessageList.get(3).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-null-57\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-null-57" + System.lineSeparator()
                 , onMessageList.get(4).toString());
         executionPlanRuntime.shutdown();
 
@@ -474,11 +474,11 @@ public class TestCaseOfCSVSinkMapper {
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 2, wso2Count.get());
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 1, ibmCount.get());
         //assert default mapping
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-55.6-100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-55.6-100" + System.lineSeparator(),
                                  onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-75.6-100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-75.6-100" + System.lineSeparator(),
                                  onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-57.6-100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-57.6-100" + System.lineSeparator(),
                                  onMessageList.get(2).toString());
         executionPlanRuntime.shutdown();
 
@@ -550,11 +550,11 @@ public class TestCaseOfCSVSinkMapper {
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 2, wso2Count.get());
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 1, ibmCount.get());
         //assert custom csv
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,100,55.6\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,100,55.6" + System.lineSeparator()
                 , onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,100,75.6\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,100,75.6" + System.lineSeparator()
                 , onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,100,57.6\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,100,57.6" + System.lineSeparator()
                 , onMessageList.get(2).toString());
         executionPlanRuntime.shutdown();
 
@@ -609,11 +609,11 @@ public class TestCaseOfCSVSinkMapper {
         //assert event count
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 3, companyCount.get());
         //assert default mapping
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2#@$,100,55.6\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2#@$,100,55.6" + System.lineSeparator(),
                                  onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,100,75.6\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,100,75.6" + System.lineSeparator(),
                                  onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "null,100,null\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "null,100,null" + System.lineSeparator()
                 , onMessageList.get(2).toString());
         executionPlanRuntime.shutdown();
 
@@ -681,11 +681,11 @@ public class TestCaseOfCSVSinkMapper {
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 2, wso2Count.get());
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 1, ibmCount.get());
         //assert custom csv
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-100-55.6\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-100-55.6" + System.lineSeparator()
                 , onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-100-75.6\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-100-75.6" + System.lineSeparator()
                 , onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-100-57.6\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2-100-57.6" + System.lineSeparator()
                 , onMessageList.get(2).toString());
         executionPlanRuntime.shutdown();
 
@@ -739,11 +739,11 @@ public class TestCaseOfCSVSinkMapper {
         //assert event count
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 3, companyCount.get());
         //assert default mapping
-        AssertJUnit.assertEquals("Incorrect mapping!", "null,100,56\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "null,100,56" + System.lineSeparator(),
                                  onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,100,null\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,100,null" + System.lineSeparator(),
                                  onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,null,56\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,null,56" + System.lineSeparator(),
                                  onMessageList.get(2).toString());
         executionPlanRuntime.shutdown();
 
@@ -795,11 +795,13 @@ public class TestCaseOfCSVSinkMapper {
         //assert event count
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 4, companyCount.get());
         //assert default mapping
-        AssertJUnit.assertEquals("Incorrect mapping!", "symbol-volume-price\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "symbol-volume-price" + System.lineSeparator(),
                                  onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2#@$-100-55.6\r\n", onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-100-75.6\r\n", onMessageList.get(2).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "null-100-null\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2#@$-100-55.6" +
+                System.lineSeparator(), onMessageList.get(1).toString());
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-100-75.6" + System.lineSeparator(),
+                onMessageList.get(2).toString());
+        AssertJUnit.assertEquals("Incorrect mapping!", "null-100-null" + System.lineSeparator()
                 , onMessageList.get(3).toString());
         executionPlanRuntime.shutdown();
 
@@ -865,9 +867,9 @@ public class TestCaseOfCSVSinkMapper {
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 1, wso2Count.get());
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 1, ibmCount.get());
         //assert custom csv
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,55.6,100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2,55.6,100" + System.lineSeparator(),
                                  onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,75.6,100\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM,75.6,100" + System.lineSeparator(),
                                  onMessageList.get(1).toString());
         executionPlanRuntime.shutdown();
 
@@ -949,13 +951,13 @@ public class TestCaseOfCSVSinkMapper {
         //assert event count
         AssertJUnit.assertEquals("Incorrect number of events consumed!", 4, companyCount.get());
         //assert default mapping
-        AssertJUnit.assertEquals("Incorrect mapping!", "symbol-volume-price\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "symbol-volume-price" + System.lineSeparator()
                 , onMessageList.get(0).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "null-100-null\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "null-100-null" + System.lineSeparator(),
                                  onMessageList.get(3).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2#@$-100-55.6\r\n"
+        AssertJUnit.assertEquals("Incorrect mapping!", "WSO2#@$-100-55.6" + System.lineSeparator()
                 , onMessageList.get(1).toString());
-        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-100-75.6\r\n",
+        AssertJUnit.assertEquals("Incorrect mapping!", "IBM-100-75.6" + System.lineSeparator(),
                                  onMessageList.get(2).toString());
         executionPlanRuntime.shutdown();
         //unsubscribe from "inMemory" broker per topic


### PR DESCRIPTION
## Purpose
$subject

## Approach
Override default record separator

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes